### PR TITLE
SD Logging Fix2

### DIFF
--- a/examples/DefaultBoard/DefaultBoard.ino
+++ b/examples/DefaultBoard/DefaultBoard.ino
@@ -6,6 +6,7 @@
 #include <OpenBCI_32bit_Library.h>
 #include <OpenBCI_32bit_Library_Definitions.h>
 
+
 // Booleans Required for SD_Card_Stuff.ino
 boolean addAccelToSD = false; // On writeDataToSDcard() call adds Accel data to SD card write
 boolean addAuxToSD = false; // On writeDataToSDCard() call adds Aux data to SD card write
@@ -14,8 +15,11 @@ boolean SDfileOpen = false; // Set true by SD_Card_Stuff.ino on successful file 
 void setup() {
   // Bring up the OpenBCI Board
   board.begin();
+
   // Bring up wifi
   wifi.begin(true, true);
+
+
 }
 
 void loop() {

--- a/examples/DefaultBoard/SD_Card_Stuff.ino
+++ b/examples/DefaultBoard/SD_Card_Stuff.ino
@@ -1,4 +1,4 @@
-#define BLOCK_5MIN    16832           
+#define BLOCK_5MIN    16890 
 #define BLOCK_15MIN  (BLOCK_5MIN*3)    
 #define BLOCK_30MIN  (BLOCK_15MIN*2)   
 #define BLOCK_1HR    (BLOCK_30MIN*2)  
@@ -7,10 +7,13 @@
 #define BLOCK_12HR   (BLOCK_1HR*12)  
 #define BLOCK_24HR   (BLOCK_1HR*24) 
 
-#define OVER_DIM 20 // make room for up to 20 write-time overruns
+#define OVER_DIM      20 // make room for up to 20 write-time overruns
+#define ERROR_LED     false
+#define OK_LED        true
 
-char fileSize = '0';  // SD file size indicator
-int blockCounter = 0;
+char    fileSize = '0';  // SD file size indicator
+int blockCounter =  0 ;
+
 
 uint32_t BLOCK_COUNT;
 SdFile openfile;  // want to put this before setup...
@@ -25,15 +28,20 @@ int byteCounter = 0;    // used to hold position in cache
 boolean openvol;
 boolean cardInit = false;
 boolean fileIsOpen = false;
+uint8_t BLOCK_DIV = 1; // DEFAULT VALUE
 
 struct {
   uint32_t block;   // holds block number that over-ran
   uint32_t micro;  // holds the length of this of over-run
 } over[OVER_DIM];
+
 uint32_t overruns;      // count the number of overruns
 uint32_t maxWriteTime;  // keep track of longest write time
 uint32_t minWriteTime;  // and shortest write time
 uint32_t t;        // used to measure total file write time
+uint8_t ERROR_BLINKS = 3;
+uint8_t OK_BLINKS    = 3;
+
 
 byte fileTens, fileOnes;  // enumerate succesive files on card and store number in EEPROM
 char currentFileName[] = "OBCI_00.TXT"; // file name will enumerate in hex 00 - FF
@@ -47,8 +55,30 @@ prog_char stopStamp[] PROGMEM = {  "%STOP AT\n"};      // used to stamp SD recor
 prog_char startStamp[] PROGMEM = {  "%START AT\n"};    // used to stamp SD record when started by PC
 
 
-char sdProcessChar(char character) {
 
+bool LED_SD_Status_Indication(uint8_t blinks_num, uint8_t blink_period_num, bool ok_indication){
+  
+  for(uint8_t i=0; i<blinks_num; i++){
+     digitalWrite(OPENBCI_PIN_LED, LOW);
+     delay(blink_period_num);
+     digitalWrite(OPENBCI_PIN_LED, HIGH);
+     delay(blink_period_num);
+  }
+  
+  if(ok_indication){
+    digitalWrite(OPENBCI_PIN_LED,HIGH);
+    return true;
+  }else {
+    digitalWrite(OPENBCI_PIN_LED,LOW);
+    return false;
+  }
+  
+}
+
+
+
+char sdProcessChar(char character) {
+  
     switch (character) {
         case 'A': // 5min
         case 'S': // 15min
@@ -59,34 +89,54 @@ char sdProcessChar(char character) {
         case 'K': // 12hr
         case 'L': // 24hr
         case 'a': // 512 blocks
+             
             fileSize = character;
             SDfileOpen = setupSDcard(character);
             break;
+            
         case 'j': // close the file, if it's open
             if(SDfileOpen){
+
                 SDfileOpen = closeSDfile();
             }
+            if(board.streaming)board.streamStop(); // Stop streamming 
             break;
+            
         case 's':
             if(SDfileOpen) {
+              
                 stampSD(ACTIVATE);
             }
             break;
+            
         case 'b':
             if(SDfileOpen) {
                 stampSD(DEACTIVATE);
-            }
+            } 
             break;
+
+        case 'c':
+        	   // Consider 8-Channels - Single Cyton Board
+            BLOCK_DIV = 2;
+            break;
+            
+         case 'C': 
+            // Consider 16-Channels - Daisy attached on Cyton Board
+            BLOCK_DIV = 1;
+            break;
+            
         default:
             break;
+        
     }
+
     return character;
 
 }
 
 
 boolean setupSDcard(char limit){
-
+    
   if(!cardInit){
       if(!card.init(SPI_FULL_SPEED, SD_SS)) {
         if(!board.streaming) {
@@ -109,28 +159,30 @@ boolean setupSDcard(char limit){
       }
    }
 
+
+       
   // use limit to determine file size
   switch(limit){
     case 'h':
-      BLOCK_COUNT = 50; break;
+      BLOCK_COUNT = 50/BLOCK_DIV; break;
     case 'a':
-      BLOCK_COUNT = 512; break;
+      BLOCK_COUNT = 512/BLOCK_DIV; break;
     case 'A':
-      BLOCK_COUNT = BLOCK_5MIN; break;
+      BLOCK_COUNT = BLOCK_5MIN/BLOCK_DIV; break;
     case 'S':
-      BLOCK_COUNT = BLOCK_15MIN; break;
+      BLOCK_COUNT = BLOCK_15MIN/BLOCK_DIV; break;
     case 'F':
-      BLOCK_COUNT = BLOCK_30MIN; break;
+      BLOCK_COUNT = BLOCK_30MIN/BLOCK_DIV; break;
     case 'G':
-      BLOCK_COUNT = BLOCK_1HR; break;
+      BLOCK_COUNT = BLOCK_1HR/BLOCK_DIV; break;
     case 'H':
-      BLOCK_COUNT = BLOCK_2HR; break;
+      BLOCK_COUNT = BLOCK_2HR/BLOCK_DIV; break;
     case 'J':
-      BLOCK_COUNT = BLOCK_4HR; break;
+      BLOCK_COUNT = BLOCK_4HR/BLOCK_DIV; break;
     case 'K':
-      BLOCK_COUNT = BLOCK_12HR; break;
+      BLOCK_COUNT = BLOCK_12HR/BLOCK_DIV; break;
     case 'L':
-      BLOCK_COUNT = BLOCK_24HR; break;
+      BLOCK_COUNT = BLOCK_24HR/BLOCK_DIV; break;
     default:
       if(!board.streaming) {
         Serial0.println("invalid BLOCK count");
@@ -139,6 +191,7 @@ boolean setupSDcard(char limit){
       return fileIsOpen;
   }
 
+ 
   incrementFileCounter();
   openvol = root.openRoot(volume);
   openfile.remove(root, currentFileName); // if the file is over-writing, let it!
@@ -146,6 +199,8 @@ boolean setupSDcard(char limit){
   if (!openfile.createContiguous(root, currentFileName, BLOCK_COUNT*512UL)) {
     if(!board.streaming) {
       Serial0.print("createfdContiguous fail");
+      LED_SD_Status_Indication(ERROR_BLINKS, 500, ERROR_LED);
+      
     }
     cardInit = false;
   }//else{Serial0.print("got contiguous file...");delay(1);}
@@ -153,21 +208,28 @@ boolean setupSDcard(char limit){
   if (!openfile.contiguousRange(&bgnBlock, &endBlock)) {
     if(!board.streaming) {
       Serial0.print("get contiguousRange fail");
+      LED_SD_Status_Indication(ERROR_BLINKS, 500, ERROR_LED);
+   
     }
     cardInit = false;
   }//else{Serial0.print("got file range...");delay(1);}
+  
   // grab the Cache
   pCache = (uint8_t*)volume.cacheClear();
+  
   // tell card to setup for multiple block write with pre-erase
   if (!card.erase(bgnBlock, endBlock)){
     if(!board.streaming) {
       Serial0.println("erase block fail");
+      LED_SD_Status_Indication(ERROR_BLINKS, 500, ERROR_LED);
     }
     cardInit = false;
   }//else{Serial0.print("erased...");delay(1);}
+ 
   if (!card.writeStart(bgnBlock, BLOCK_COUNT)){
     if(!board.streaming) {
       Serial0.println("writeStart fail");
+      LED_SD_Status_Indication(ERROR_BLINKS, 500, ERROR_LED);
     }
     cardInit = false;
   } else{
@@ -175,6 +237,7 @@ boolean setupSDcard(char limit){
     delay(1);
   }
   board.csHigh(SD_SS);  // release the spi
+  
   // initialize write-time overrun error counter and min/max wirte time benchmarks
   overruns = 0;
   maxWriteTime = 0;
@@ -185,6 +248,7 @@ boolean setupSDcard(char limit){
     if(!board.streaming) {
       Serial0.print("Corresponding SD file ");
       Serial0.println(currentFileName);
+      LED_SD_Status_Indication(OK_BLINKS, 250, OK_LED);
     }
   }
   if(!board.streaming) {
@@ -193,7 +257,13 @@ boolean setupSDcard(char limit){
   return fileIsOpen;
 }
 
+
+
+
+
+
 boolean closeSDfile(){
+
   if(fileIsOpen){
     board.csLow(SD_SS);  // take spi
     card.writeStop();
@@ -212,15 +282,20 @@ boolean closeSDfile(){
         for (uint8_t i = 0; i < n; i++) {
           Serial0.print(over[i].block); Serial0.print(','); Serial0.println(over[i].micro);
         }
+        
       }
       board.sendEOT();
     }
+
+
   }else{
     if(!board.streaming) {
       Serial0.println("No open file to close");
       board.sendEOT();
     }
+    
   }
+  
   // delay(100); // cool down
   return fileIsOpen;
 }
@@ -234,13 +309,18 @@ void writeDataToSDcard(byte sampleNumber){
   // convert 24 bit channelData into HEX
   for (int currentChannel = 0; currentChannel < 8; currentChannel++){
     convertToHex(board.boardChannelDataInt[currentChannel], 5, addComma);
+    
+    // If Daisy Is NOT Attached -> stop putting comma delimiter at 7th sample 
     if(board.daisyPresent == false){
       if(currentChannel == 6){
         addComma = false;
-        if(addAuxToSD || addAccelToSD) {addComma = true;}  // format CSV
+        if(addAuxToSD || addAccelToSD) { addComma = true; }  // format CSV
       }
     }
-  }
+    
+   } 
+
+   // If Daisy Is Attached -> stop putting comma delimiter at 7th sample
   if(board.daisyPresent){
     for (int currentChannel = 0; currentChannel < 8; currentChannel++){
       convertToHex(board.daisyChannelDataInt[currentChannel], 5, addComma);
@@ -249,7 +329,10 @@ void writeDataToSDcard(byte sampleNumber){
         if(addAuxToSD || addAccelToSD) {addComma = true;}  // format CSV
       }
     }
+    
   }
+
+  
 
   if(addAuxToSD == true){
     // convert auxData into HEX
@@ -259,6 +342,8 @@ void writeDataToSDcard(byte sampleNumber){
     }
     addAuxToSD = false;
   }// end of aux data log
+
+  
   else if(addAccelToSD == true){  // if we have accelerometer data to log
     // convert 16 bit accelerometer data into HEX
     for (int currentChannel = 0; currentChannel < 3; currentChannel++){
@@ -272,7 +357,9 @@ void writeDataToSDcard(byte sampleNumber){
 }
 
 
+
 void writeCache(){
+    
     if(blockCounter > BLOCK_COUNT) {
       blockCounter=0; 
       return;
@@ -297,19 +384,19 @@ void writeCache(){
       }
       overruns++;
     }
-    
+
     byteCounter = 0; // reset 512 byte counter for next block
     blockCounter++;    // increment BLOCK counter
     
     if(blockCounter == BLOCK_COUNT-1){
       t = millis() - t;
+
       // Time to Close the file but do not stop Streaming 
       writeFooter();
     }
     
     if(blockCounter == BLOCK_COUNT){
-      SDfileOpen  = closeSDfile(); // Update open-file flag 
-      BLOCK_COUNT = 0;
+       SDfileOpen  = closeSDfile(); // Update open-file flag     
     }  // we did it!
     
 }
@@ -346,6 +433,7 @@ void incrementFileCounter(){
 
 
 void stampSD(boolean state){
+
   unsigned long time = millis();
   if(state){
     for(int i=0; i<10; i++){
@@ -368,7 +456,11 @@ void stampSD(boolean state){
   convertToHex(time, 7, false);
 }
 
+
+
+
 void writeFooter(){
+ 
   for(int i=0; i<16; i++){
     pCache[byteCounter] = pgm_read_byte_near(samplingFreq+i);
     byteCounter++;
@@ -399,10 +491,12 @@ void writeFooter(){
     byteCounter++;
   }
   convertToHex(overruns, 7, false);
+
   for(int i=0; i<11; i++){
     pCache[byteCounter] = pgm_read_byte_near(blockTime+i);
     byteCounter++;
   }
+
   if (overruns) {
     uint8_t n = overruns > OVER_DIM ? OVER_DIM : overruns;
     for (uint8_t i = 0; i < n; i++) {
@@ -410,11 +504,16 @@ void writeFooter(){
       convertToHex(over[i].micro, 7, false);
     }
   }
+
   for(int i=byteCounter; i<512; i++){
     pCache[i] = NULL;
   }
+ 
   writeCache();
 }
+
+
+
 
 //    CONVERT RAW BYTE DATA TO HEX FOR SD STORAGE
 void convertToHex(long rawData, int numNibbles, boolean useComma){


### PR DESCRIPTION
- Fixed - SD Logging and Footer Fixed for Daisy and Not Daisy Attached
- Added -  LED Indication for Successful or Failed SD Card File Creation
- LED  Indication:
        + GUI -> Start Streaming Session -> 3 Slow Blinks -> SD File Created Correctly -> then the LED stays Solid Blue (Data Logging started successfully)
       + GUI Start Session : Indication of 12 Slow Blinks -> then the LED is turned OFF  (Data will not be stored in this session) cause : SD File Creation FAILED ->
   Solution:
        A. you need to restart the streaming session
       or  B. delete all the previous files form the SD Card
       or  C. format the SD card completely
  At any case check again for the LED sequence (3 Blinks->ON versus 12 blinks->OFF)